### PR TITLE
use separate env vars for rc and rel repos

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
   publish-rc-images:
     machine: true
     environment:
-      DOCKER_REPO: quay.io/deisci/
+      RC_DOCKER_REPO: quay.io/deisci/
     steps:
       - checkout
       - run:
@@ -22,7 +22,8 @@ jobs:
   publish-release-images:
     machine: true
     environment:
-      DOCKER_REPO: quay.io/deis/
+      RC_DOCKER_REPO: quay.io/deisci/
+      REL_DOCKER_REPO: quay.io/deis/
     steps:
       - checkout
       - run:

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,11 @@ GIT_VERSION = $(shell git describe --always --abbrev=7 --dirty)
 
 BASE_IMAGE_NAME        = lightweight-docker-go
 
-RC_IMAGE_NAME          = $(DOCKER_REPO)$(BASE_IMAGE_NAME):$(GIT_VERSION)
-RC_MUTABLE_IMAGE_NAME  = $(DOCKER_REPO)$(BASE_IMAGE_NAME):canary
+RC_IMAGE_NAME          = $(RC_DOCKER_REPO)$(BASE_IMAGE_NAME):$(GIT_VERSION)
+RC_MUTABLE_IMAGE_NAME  = $(RC_DOCKER_REPO)$(BASE_IMAGE_NAME):canary
 
-REL_IMAGE_NAME         = $(DOCKER_REPO)$(BASE_IMAGE_NAME):$(REL_VERSION)
-REL_MUTABLE_IMAGE_NAME = $(DOCKER_REPO)$(BASE_IMAGE_NAME):latest
+REL_IMAGE_NAME         = $(REL_DOCKER_REPO)$(BASE_IMAGE_NAME):$(REL_VERSION)
+REL_MUTABLE_IMAGE_NAME = $(REL_DOCKER_REPO)$(BASE_IMAGE_NAME):latest
 
 # Checks for the existence of a docker client and prints a nice error message
 # if it isn't present


### PR DESCRIPTION
This is just to better accommodate the way we've always done things on quay. Separate accounts are used for rc / canary images and officially released images.